### PR TITLE
Add single entry fasta support

### DIFF
--- a/core/input_file.cpp
+++ b/core/input_file.cpp
@@ -22,7 +22,7 @@ CInputFile::~CInputFile()
 }
 
 // *******************************************************************
-bool CInputFile::ReadFile(string file_name)
+int CInputFile::ReadFile(string file_name)
 {
 	istream* in;
 
@@ -66,7 +66,7 @@ bool CInputFile::ReadFile(string file_name)
 	if(!id.empty() && !seq.empty())
 		sequences.push_back(CSequence(id, seq));
 
-	return sequences.size() > 1;
+	return sequences.size();
 }
 
 // *******************************************************************

--- a/core/input_file.cpp
+++ b/core/input_file.cpp
@@ -22,7 +22,7 @@ CInputFile::~CInputFile()
 }
 
 // *******************************************************************
-int CInputFile::ReadFile(string file_name)
+size_t CInputFile::ReadFile(string file_name)
 {
 	istream* in;
 

--- a/core/input_file.h
+++ b/core/input_file.h
@@ -25,7 +25,7 @@ public:
 	CInputFile();
 	~CInputFile();
 
-	int ReadFile(string file_name);
+	size_t ReadFile(string file_name);
 
 	void GetSequences(vector<CSequence> &_sequences) const;
 	void StealSequences(vector<CSequence> &_sequences);

--- a/core/input_file.h
+++ b/core/input_file.h
@@ -25,7 +25,7 @@ public:
 	CInputFile();
 	~CInputFile();
 
-	bool ReadFile(string file_name);
+	int ReadFile(string file_name);
 
 	void GetSequences(vector<CSequence> &_sequences) const;
 	void StealSequences(vector<CSequence> &_sequences);

--- a/core/msa.cpp
+++ b/core/msa.cpp
@@ -847,7 +847,7 @@ bool CFAMSA::LoadRefSequences()
 	if (params.verbose_mode)
 		cerr << "Processing reference sequence set: " << params.ref_file_name << "\n";
 
-	if (!ref_file.ReadFile(params.ref_file_name))
+	if (ref_file.ReadFile(params.ref_file_name) < 2)
 	{
 		cout << "Error: no (or incorrect) input file\n";
 		return false;

--- a/famsa_cpu/famsa_cpu.cpp
+++ b/famsa_cpu/famsa_cpu.cpp
@@ -324,13 +324,22 @@ int main(int argc, char *argv[])
 	if (execution_params.verbose_mode)
 		cerr << "Processing: " << execution_params.input_file_name << "\n";
 
-	if(!in_file.ReadFile(execution_params.input_file_name))
-	{
-		cout << "Error: no (or incorrect) input file\n";
+	vector<CGappedSequence*> result;
+	vector<CSequence> sequences;
+
+	size_t input_seq_cnt = in_file.ReadFile(execution_params.input_file_name);
+    if(input_seq_cnt == 0){			
+    	cout << "Error: no (or incorrect) input file\n";
 		return 0;
+	} else if (input_seq_cnt == 1){
+		in_file.StealSequences(sequences);
+        CGappedSequence resultSeq(sequences[0]);
+		result.push_back(&resultSeq);
+		out_file.PutSequences(std::move(result));
+	    out_file.SaveFile(execution_params.output_file_name);
+        return 0;
 	}
 
-	vector<CSequence> sequences;
 
 	in_file.StealSequences(sequences);
 
@@ -350,7 +359,6 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-	vector<CGappedSequence*> result;
 	famsa.GetAlignment(result);
 
 	out_file.PutSequences(std::move(result));

--- a/famsa_gpu/famsa_gpu.cpp
+++ b/famsa_gpu/famsa_gpu.cpp
@@ -339,14 +339,23 @@ int main(int argc, char *argv[])
 
 	if (execution_params.verbose_mode)
 		cerr << "Processing: " << execution_params.input_file_name << "\n";
+	
+	vector<CGappedSequence*> result;
+	vector<CSequence> sequences;
 
-	if(!in_file.ReadFile(execution_params.input_file_name))
-	{
-		cout << "Error: no (or incorrect) input file\n";
+	size_t input_seq_cnt = in_file.ReadFile(execution_params.input_file_name);
+    if(input_seq_cnt == 0){			
+    	cout << "Error: no (or incorrect) input file\n";
 		return 0;
+	} else if (input_seq_cnt == 1){
+		in_file.StealSequences(sequences);
+        CGappedSequence resultSeq(sequences[0]);
+		result.push_back(&resultSeq);
+		out_file.PutSequences(std::move(result));
+	    out_file.SaveFile(execution_params.output_file_name);
+        return 0;
 	}
 
-	vector<CSequence> sequences;
 
 	in_file.StealSequences(sequences);
 
@@ -366,7 +375,6 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-	vector<CGappedSequence*> result;
 	famsa.GetAlignment(result);
 
 	out_file.PutSequences(std::move(result));


### PR DESCRIPTION
I added support for single entry fasta files. This features make using FAMSA more convenient in automated pipelines because the user does not need to distinguish between singleton and multi entry fasta files.