### PR TITLE
Fix * char emitted for unknown residues, emits X instead

### DIFF
--- a/core/defs.h
+++ b/core/defs.h
@@ -66,7 +66,7 @@ const symbol_t GAP_OPEN       = 25;
 const symbol_t GAP_EXT        = 26;
 const symbol_t GAP_TERM_EXT   = 27;
 const symbol_t GAP_TERM_OPEN  = 28;
-const symbol_t UNKNOWN_SYMBOL = 23;
+const symbol_t UNKNOWN_SYMBOL = 22;
 
 const size_t   NO_SYMBOLS				= 32;			// alphabet of protein sequences (including gaps and special symbols)
 const symbol_t GUARD					= (symbol_t) (NO_SYMBOLS) - 1;


### PR DESCRIPTION
We are currently evaluating replacing clustalo with famsa in the Uniclust/Uniref HHblits database workflow. We aligning nearly 7 million non-singleton clusters of a Uniref clustered to 30% seq.id. with famsa. About 800 MSAs were failing in later stages. After manually looking at a few of those I found that they contained stop codons `*` and originally Selenocysteine (`U`) or Pyrrolysine (`O`). This emits the unknown residue `X` instead.

The gpu branch of the code also defines this constant, however since I do not have a GPU to test my changes. I did not touch that code.

Alternatively the code could be reworked to also support the three missing residues `O`, `U` and `J`. However, for my purposes, I would prefer to emit `X`.