### PR TITLE
Fix typo in include guards in `msa.cpp`

### DIFF
--- a/src/msa.cpp
+++ b/src/msa.cpp
@@ -84,7 +84,7 @@ void CFAMSA::initScoreMatrix()
 {
 	score_matrix.resize(NO_AMINOACIDS);
 
-#ifdef HUGE_ALIGNEMENTS
+#ifdef HUGE_ALIGNMENTS
 	for(int i = 0; i < NO_AMINOACIDS; ++i)
 	{
 		score_vector.emplace_back(SM_MIQS[i][i]);


### PR DESCRIPTION
Hi!

There is a typo in `msa.cpp`, the include guards were guarding for `HUGE_ALIGNEMENTS` when it should be `HUGE_ALIGNMENTS`. This shouldn't change anything given that `HUGE_ALIGNMENTS` was never defined normally, but I guess it could cause some mis-configuration of the scoring matrix otherwise :smile: 