### PR TITLE
Fix off-by-one error in `GappedSequence` constructor

### DIFF
--- a/src/core/sequence.cpp
+++ b/src/core/sequence.cpp
@@ -255,10 +255,10 @@ CGappedSequence::CGappedSequence(const string& _id, const string& seq, int seq_n
 			char* q = find(mapping_table, mapping_table + 25, c);
 			if (q == mapping_table + 25) {
 				extra_symbols.emplace_back(is, c); // save non-standard symbol
-				symbols[is] = (symbol_t)UNKNOWN_SYMBOL;
+				symbols[is+1] = (symbol_t)UNKNOWN_SYMBOL;
 			}
 			else {
-				symbols[is] = (symbol_t)(q - mapping_table);
+				symbols[is+1] = (symbol_t)(q - mapping_table);
 			}
 
 			++is;

--- a/src/core/sequence.cpp
+++ b/src/core/sequence.cpp
@@ -231,6 +231,7 @@ CGappedSequence::CGappedSequence(const string& _id, const string& seq, int seq_n
 			symbols=(symbol_t*)mma->allocate(symbols_size + 1);}
 		else {
 			symbols=new symbol_t[symbols_size +1];}
+                symbols[0]=GUARD;
 	}
 	else {
 		symbols=nullptr;

--- a/src/core/sequence.cpp
+++ b/src/core/sequence.cpp
@@ -313,7 +313,7 @@ CGappedSequence::CGappedSequence(const CGappedSequence& _gapped_sequence) :
 		symbols = new symbol_t[symbols_size + 1];
 
 	
-	copy_n(_gapped_sequence.symbols, symbols_size, symbols);
+	copy_n(_gapped_sequence.symbols, symbols_size + 1, symbols);
 
 	n_gaps = _gapped_sequence.n_gaps;
 	dps = _gapped_sequence.dps;


### PR DESCRIPTION
Hi @agudys!

There is an off-by-one error in the encoding constructor of `GappedSequence`. The symbols should be written to the symbol array starting from offset 1, but currently starts at offset 0. This causes issues with the internal sequence representation, and with the decoding as well. Luckily this constructor is actually not used anywhere in FAMSA, but when I tried wrapping it in PyFAMSA I started getting weird issues and traced it back here!