### PR TITLE
Add riscv64 as a target architecture

### DIFF
--- a/libs/refresh/active_thread_pool/lib/utils.h
+++ b/libs/refresh/active_thread_pool/lib/utils.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cinttypes>
+#include <thread>
 
 namespace refresh
 {
@@ -14,6 +15,14 @@ namespace refresh
 			_mm_pause();
 #elif defined(__aarch64__)
 			std::this_thread::yield();
+#elif defined(__riscv) && (__riscv_xlen == 64)
+    #if defined(__riscv_zihintpause)
+			// Use the RISC-V pause hint if available
+			__asm__ __volatile__("pause");
+    #else
+			// Fallback: yield to scheduler to reduce power while spinning
+			std::this_thread::yield();
+    #endif
 #else
 			__builtin_ia32_pause();
 			//			_mm_pause();

--- a/makefile
+++ b/makefile
@@ -3,9 +3,9 @@ all: famsa
 # *** REFRESH makefile utils
 include refresh.mk
 
-$(call INIT_SUBMODULES)
-$(call INIT_GLOBALS)
-$(call CHECK_OS_ARCH, $(PLATFORM))
+$(eval $(call INIT_SUBMODULES))
+$(eval $(call INIT_GLOBALS))
+$(eval $(call CHECK_OS_ARCH,$(PLATFORM)))
 
 
 # *** Project directories

--- a/makefile
+++ b/makefile
@@ -7,19 +7,6 @@ $(call INIT_SUBMODULES)
 $(call INIT_GLOBALS)
 $(call CHECK_OS_ARCH, $(PLATFORM))
 
-# RISC-V specific override (must come after CHECK_OS_ARCH)
-# Usage:
-#   make PLATFORM=rv64g   -> generic scalar rv64g
-#   make PLATFORM=rv64gcv -> vector extension rv64gcv (placeholder macro SIMD_RVV)
-ifeq ($(ARCH_TYPE),riscv64)
-ifneq ($(findstring rv64gcv,$(PLATFORM)),)
-ARCH_FLAGS=-march=rv64gcv -mabi=lp64d -DARCH_RISCV -DSIMD_RVV
-$(info *** RISC-V rv64gcv with vector extension (SIMD_RVV placeholder) ***)
-else
-ARCH_FLAGS=-march=rv64g -mabi=lp64d -DARCH_RISCV
-$(info *** RISC-V rv64g generic (scalar fallback) ***)
-endif
-endif
 
 # *** Project directories
 $(call SET_SRC_OBJ_BIN,src,obj,bin)
@@ -43,6 +30,7 @@ $(call SET_FLAGS, $(TYPE))
 
 $(call SET_COMPILER_VERSION_ALLOWED, GCC, Linux_x86_64, 11, 20)
 $(call SET_COMPILER_VERSION_ALLOWED, GCC, Linux_aarch64, 11, 20)
+$(call SET_COMPILER_VERSION_ALLOWED, GCC, Linux_riscv64, 11, 20)
 $(call SET_COMPILER_VERSION_ALLOWED, GCC, Darwin_x86_64, 11, 13)
 $(call SET_COMPILER_VERSION_ALLOWED, GCC, Darwin_arm64, 11, 13)
 

--- a/refresh.mk
+++ b/refresh.mk
@@ -618,75 +618,36 @@ define CHECK_OS_ARCH
 	$(if $(shell grep -q 'avx512' /proc/cpuinfo && echo yes),$(eval CPU_EXTENSIONS_DEFS+=-DSIMD_AVX512),)
 	$(if $(shell grep -q 'neon' /proc/cpuinfo && echo yes),$(eval CPU_EXTENSIONS_DEFS+=-DSIMD_NEON),)
 
-	# Platform-specific override based on provided PLATFORM argument $(1)
-	# RISC-V first (rv64g / rv64gcv)
-	$(if $(filter rv64gcv,$(1)), \
-		$(eval ARCH_FLAGS:=-march=rv64gcv -mabi=lp64d -DARCH_RISCV -DSIMD_RVV) \
-		$(info *** RISC-V rv64gcv with vector extension (SIMD_RVV) ***), \
-		$(if $(filter rv64g,$(1)), \
-			$(eval ARCH_FLAGS:=-march=rv64g -mabi=lp64d -DARCH_RISCV) \
-			$(info *** RISC-V rv64g generic (scalar) ***), \
-			$(if $(filter arm8,$(1)), \
-				$(eval ARCH_FLAGS:=-march=armv8-a -DARCH_ARM) \
-				$(info *** ARMv8 with NEON extensions ***), \
-				$(if $(filter m1,$(1)), \
-					$(eval ARCH_FLAGS:=-march=armv8.4-a -DARCH_ARM -DSIMD_NEON) \
-					$(info *** Apple M1 (or newer) with NEON extensions ***), \
-					$(if $(filter sse2,$(1)), \
-						$(eval ARCH_FLAGS:=-msse2 -m64 -DARCH_X64 -DSIMD_SSE2) \
-						$(info *** x86-64 with SSE2 extensions ***), \
-						$(if $(filter avx,$(1)), \
-							$(eval ARCH_FLAGS:=-mavx -m64 -DARCH_X64 -DSIMD_AVX) \
-							$(info *** x86-64 with AVX extensions ***), \
-							$(if $(filter avx2,$(1)), \
-								$(eval ARCH_FLAGS:=-mavx2 -m64 -DARCH_X64 -DSIMD_AVX2) \
-								$(info *** x86-64 with AVX2 extensions ***), \
-								$(if $(filter avx512,$(1)), \
-									$(eval ARCH_FLAGS:=-mavx512f -mavx512dq -m64 -DARCH_X64 -DSIMD_AVX512) \
-									$(info *** x86-64 with AVX512 extensions ***), \
-									$(if $(filter generic,$(1)), \
-										$(if $(filter x86_64,$(ARCH_TYPE)), \
-											$(eval ARCH_FLAGS:=-DARCH_X64) \
-											$(info *** Unspecified platform - using generic compilation for x86_64 ***), \
-											$(if $(filter arm%,$(ARCH_TYPE)), \
-												$(eval ARCH_FLAGS:=-DARCH_ARM -DSIMD_NEON) \
-												$(info *** Unspecified platform - using generic compilation for ARM ***), \
-												$(if $(filter riscv64,$(ARCH_TYPE)), \
-													$(eval ARCH_FLAGS:=-DARCH_RISCV) \
-													$(info *** Unspecified platform - using generic compilation for RISC-V ***), \
-												) \
-											) \
-										, \
-										$(if $(filter x86_64,$(ARCH_TYPE)), \
-											$(eval ARCH_FLAGS:=-march=native -DARCH_X64) \
-											$(eval ARCH_FLAGS+=$(CPU_EXTENSIONS_DEFS)) \
-											$(info *** Unspecified platform - using native compilation for x86_64 ***), \
-											$(if $(filter arm%,$(ARCH_TYPE)), \
-												$(eval ARCH_FLAGS:=-march=native -DARCH_ARM -DSIMD_NEON) \
-												$(eval ARCH_FLAGS+=$(CPU_EXTENSIONS_DEFS)) \
-												$(info *** Unspecified platform - using native compilation for ARM ***), \
-												$(if $(filter riscv64,$(ARCH_TYPE)), \
-													$(eval ARCH_FLAGS:=-march=rv64g -mabi=lp64d -DARCH_RISCV) \
-													$(info *** Unspecified platform - using native compilation for RISC-V rv64g ***), \
-												) \
-											) \
-										) \
-									) \
-								) \
-							) \
-						) \
-					) \
-				) \
+	# Simplified platform selection to avoid deep nested if() causing syntax errors
+	$(eval PLATFORM_ARG:=$(strip $(1)))
+	# Explicit targets
+	$(if $(filter rv64gcv,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-march=rv64gcv -mabi=lp64d -DARCH_RISCV -DSIMD_RVV) $(info *** RISC-V rv64gcv (vector) ***),)
+	$(if $(and $(filter rv64g,$(PLATFORM_ARG)),$(filter-out rv64gcv,$(PLATFORM_ARG))),$(eval ARCH_FLAGS:=-march=rv64g -mabi=lp64d -DARCH_RISCV) $(info *** RISC-V rv64g (scalar) ***),)
+	$(if $(filter arm8,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-march=armv8-a -DARCH_ARM) $(info *** ARMv8 ***),)
+	$(if $(filter m1,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-march=armv8.4-a -DARCH_ARM -DSIMD_NEON) $(info *** Apple M1/ARMv8.4 ***),)
+	$(if $(filter sse2,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-msse2 -m64 -DARCH_X64 -DSIMD_SSE2) $(info *** x86_64 SSE2 ***),)
+	$(if $(filter avx,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-mavx -m64 -DARCH_X64 -DSIMD_AVX) $(info *** x86_64 AVX ***),)
+	$(if $(filter avx2,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-mavx2 -m64 -DARCH_X64 -DSIMD_AVX2) $(info *** x86_64 AVX2 ***),)
+	$(if $(filter avx512,$(PLATFORM_ARG)),$(eval ARCH_FLAGS:=-mavx512f -mavx512dq -m64 -DARCH_X64 -DSIMD_AVX512) $(info *** x86_64 AVX512 ***),)
+	# Generic build
+	$(if $(filter generic,$(PLATFORM_ARG)), \
+		$(if $(filter x86_64,$(ARCH_TYPE)),$(eval ARCH_FLAGS:=-DARCH_X64) $(info *** generic x86_64 ***), \
+			$(if $(filter aarch64 arm%,$(ARCH_TYPE)),$(eval ARCH_FLAGS:=-DARCH_ARM -DSIMD_NEON) $(info *** generic ARM ***), \
+				$(if $(filter riscv64,$(ARCH_TYPE)),$(eval ARCH_FLAGS:=-DARCH_RISCV) $(info *** generic RISC-V ***),) \
+			) \
+		) \
+	,)
+	# Native fallback if still empty
+	$(if $(ARCH_FLAGS),, \
+		$(if $(filter x86_64,$(ARCH_TYPE)),$(eval ARCH_FLAGS:=-march=native -DARCH_X64 $(CPU_EXTENSIONS_DEFS)) $(info *** native x86_64 ***), \
+			$(if $(filter aarch64 arm%,$(ARCH_TYPE)),$(eval ARCH_FLAGS:=-march=native -DARCH_ARM -DSIMD_NEON $(CPU_EXTENSIONS_DEFS)) $(info *** native ARM ***), \
+				$(if $(filter riscv64,$(ARCH_TYPE)),$(eval ARCH_FLAGS:=-march=rv64g -mabi=lp64d -DARCH_RISCV) $(info *** native RISC-V rv64g ***),) \
 			) \
 		) \
 	)
-
-	# Auto-detect RISC-V vector extension if PLATFORM did not force SIMD_RVV
-	$(if $(filter riscv64,$(ARCH_TYPE)), \
-		$(if $(and $(filter-out rv64gcv,$(1)),$(shell grep -qi 'rvv' /proc/cpuinfo && echo yes)), \
-			$(eval ARCH_FLAGS:=-march=rv64gcv -mabi=lp64d -DARCH_RISCV -DSIMD_RVV) \
-			$(info *** RISC-V vector (rvv) detected; enabling SIMD_RVV ***), \
-		) \
+	# Auto-detect RVV if riscv64 native and vector present and not forced scalar
+	$(if $(and $(filter riscv64,$(ARCH_TYPE)),$(filter-out rv64gcv,$(PLATFORM_ARG))), \
+		$(if $(shell grep -qi 'rvv' /proc/cpuinfo && echo yes),$(eval ARCH_FLAGS:=-march=rv64gcv -mabi=lp64d -DARCH_RISCV -DSIMD_RVV) $(info *** auto RVV enabled ***),) \
 	)
 	
 	$(if $(filter Darwin,$(OS_TYPE)), \


### PR DESCRIPTION
Hi,

Thanks for developing FAMSA!

Firstly I must say that I am not a software engineer, I am just using the LLM coding tools. I am proposing these changes as is and I will not be able to answer technical questions about the approach. What I can say is that the changes are enough to port FAMSA to riscv64 (`-march=rv64g`). The program compiles (`gmake PLATFORM=rv64g`) and works.

Some simplification of the nested loop in `refresh.mk` is also proposed.

The specific riscv64 device I possess has the architecture `rv64imafdvcsu`, which also supports compressed and vector extensions (`rv64gcv`). It may be possible that they can make the program faster. I do not know which architecture target is most common for `riscv64` software. If superflouous, the target `rv64gcv` can be removed.